### PR TITLE
bug chrome-console preload-error

### DIFF
--- a/components/Domains/Footer.vue
+++ b/components/Domains/Footer.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="relative text-white font-noto">
-    <a
+  <div class="text-white font-noto">
+    <!-- <a
       id="page-top"
       class="absolute inline-block -top-4 lg:-top-5 right-8 lg:right-24"
       @click="scrollTop"
@@ -10,7 +10,7 @@
         alt="icon top"
         class="w-8 lg:w-10"
       />
-    </a>
+    </a> -->
     <div class="footer-upper-background">
       <div class="footer-upper">
         <img src="~/assets/images/footer-2021-logo.svg" alt="2021-logo" />
@@ -149,11 +149,11 @@ import OuterLink from '~/components/OuterLink'
 export default {
   components: { OuterLink },
 
-  methods: {
-    scrollTop() {
-      window.scrollTo(0, 0)
-    },
-  },
+  // methods: {
+  //   scrollTop() {
+  //     window.scrollTo(0, 0)
+  //   },
+  // },
 }
 </script>
 
@@ -201,7 +201,7 @@ export default {
   }
 }
 
-#page-top {
+/* #page-top {
   border-radius: 50%;
   padding: 1px;
   box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.1), 0px 2px 24px rgba(0, 0, 0, 0.08);
@@ -212,5 +212,5 @@ export default {
 }
 #page-top:hover {
   opacity: 0.85;
-}
+} */
 </style>


### PR DESCRIPTION
below error still not fixed yet.
rollback the code to see if the error gone.

error-msg: [The resource https://develop.dw6pdzztc9vl4.amplifyapp.com/_nuxt/static/1630089678/manifest.js
was preloaded using link preload but not used within a few seconds from
the window’s load event. Please make sure it has an appropriate as value
and it is preloaded intentionally.]